### PR TITLE
removed dependency on initgroups

### DIFF
--- a/bubbleio/bubbleio.py
+++ b/bubbleio/bubbleio.py
@@ -4,7 +4,6 @@ This module contans Bubbleio class to handle Bubble.io API.
 https://manual.bubble.io/core-resources/api/data-api
 """
 
-from os import initgroups
 import requests
 import logging
 import pandas as pd


### PR DESCRIPTION
Initgroups does not appear to be used. It breaks Windows compatibility, so lets just remove it.